### PR TITLE
fix broken link to libswift pdf

### DIFF
--- a/content/blog/tendermint-vs-pbft.md
+++ b/content/blog/tendermint-vs-pbft.md
@@ -2,7 +2,7 @@
 title: "Tendermint vs PBFT"
 description: "Tendermint is a variant of PBFT; similarities and differences explained"
 date: "2015-10-03"
-categories: 
+categories:
     - "consensus"
     - "pbft"
 ~~~
@@ -24,7 +24,7 @@ _terminology comparison between Tendermint and PBFT_
 
 Both PBFT and Tendermint are Byzantine fault-tolerant transaction systems.  Both can handle up to ⅓ of malicious Byzantine validators/replicas.  Both require three steps/phases;  the first for broadcasting the block, and the last two for broadcasting signatures.  Finally, both require two quorums of signatures to commit a block.
 
-Where the two differ is in what happens when more than ⅓ of validators are Byzantine.  In PBFT, when there are between ⅓ and ⅔ of Byzantine validators, no guarantees are provided whatsoever; the attackers can return arbitrary results to the client ([source](https://www.usenix.org/conference/nsdi-07/beyond-one-third-faulty-replicas-byzantine-fault-tolerant-systems)).  Tendermint’s consensus model considers a block to be committed when there are more than ⅔ of precommit signatures for the blockhash, which mitigates this issue.   Thus if ½ of the validators are Byzantine they can prevent future blocks from being committed; however, they cannot commit new blocks like they can in PBFT. 
+Where the two differ is in what happens when more than ⅓ of validators are Byzantine.  In PBFT, when there are between ⅓ and ⅔ of Byzantine validators, no guarantees are provided whatsoever; the attackers can return arbitrary results to the client ([source](https://www.usenix.org/conference/nsdi-07/beyond-one-third-faulty-replicas-byzantine-fault-tolerant-systems)).  Tendermint’s consensus model considers a block to be committed when there are more than ⅔ of precommit signatures for the blockhash, which mitigates this issue.   Thus if ½ of the validators are Byzantine they can prevent future blocks from being committed; however, they cannot commit new blocks like they can in PBFT.
 
 ## Round-robin vs sticky leaders
 
@@ -46,7 +46,7 @@ The PBFT algorithm illustrates a point-to-point consensus algorithm, which is si
 
 Tendermint goes a step further than PBFT and implements a BitTorrent/LibSwift-inspired algorithm to quickly broadcast transaction blocks.  This makes the most out of limited available bandwidth to commit transactions sooner.
 
-See [_Performance Analysis of the Libswift P2P Streaming Protocol_](http://www.ict.kth.se/courses/ID2210/presentation-papers/2012%20-%20Performance%20Analysis%20of%20Libswift.pdf) for details on how LibSwift fares in “flashcrowd” scenarios, which is similar to new block propagations in Tendermint.
+See [_Performance Analysis of the Libswift P2P Streaming Protocol_](http://www.ds.ewi.tudelft.nl/fileadmin/pds/papers/PerformanceAnalysisOfLibswift.pdf) for details on how LibSwift fares in “flashcrowd” scenarios, which is similar to new block propagations in Tendermint.
 
 ## Self-balancing Merkle trees
 


### PR DESCRIPTION
Old link results in 404 error.