### PR TITLE
Remove the word 'ninja' from job listing

### DIFF
--- a/src/store/json/careers.json
+++ b/src/store/json/careers.json
@@ -65,8 +65,8 @@
     ]
   },
   {
-    "id": "devops_ninja",
-    "title": "DevOps Ninja",
+    "id": "devops_engineer",
+    "title": "DevOps Engineer",
     "subtitle": "DevOps, Continuous Integration, Cloud, Docker, Golang",
     "tags": ["devops", "cloud", "automation"],
     "weight": 1,


### PR DESCRIPTION
## Description
Removing the word 'ninja' from the job description

## How to test
* Start server
* Go to http://localhost:8800/careers/
* The first listing should be for 'Devops Engineer'
* Click on that
* It should look like this:
![image](https://cloud.githubusercontent.com/assets/484191/21620919/92c0cacc-d1ab-11e6-80f3-802e387b0f51.png)
