### PR TITLE
content/intro: minor typo fixes

### DIFF
--- a/content/intro/#01-tendermint-vs-x.md
+++ b/content/intro/#01-tendermint-vs-x.md
@@ -33,8 +33,8 @@ The layout of this Tendermint website content is also ripped directly and withou
 
 Tendermint emerged in the tradition of cryptocurrencies like Bitcoin, Ethereum, etc.
 with the goal of providing a more efficient and secure consensus algorithm than Bitcoin's Proof of Work.
-In the early days, Tendermint had a simple currency built in, and to participate in consensus 
-user's had to "bond" units of the currency into a security deposit which could be revoked if they misbehaved - 
+In the early days, Tendermint had a simple currency built in, and to participate in consensus,
+users had to "bond" units of the currency into a security deposit which could be revoked if they misbehaved -
 this is what made Tendermint a Proof-of-Stake algorithm.
 
 Since then, Tendermint has evolved to be a general purpose blockchain consensus engine that can host arbitrary application states.
@@ -62,4 +62,4 @@ It uses Tendermint as its consensus engine, and provides a particular applicatio
 ## Next Steps
 
 - Read an overview of the motivation and design behind the [Application BlockChain Interface](/intro/abci-overview).
-- Continue with the [Getting Started](/docs/getting-started) guide to install and run example tendermint applications.
+- Continue with the [Getting Started](/docs/getting-started) guide to install and run example Tendermint applications.

--- a/content/intro/index.md
+++ b/content/intro/index.md
@@ -18,7 +18,7 @@ The theory of BFT is decades old, but software implementations have only became 
 due largely to the success of "blockchain technology" like Bitcoin and Ethereum. 
 Blockchain technology is just a reformalization of BFT in a more modern setting,
 with emphasis on peer-to-peer networking and cryptographic authentication.
-The name derrives from the way transactions are batched in blocks,
+The name derives from the way transactions are batched in blocks,
 where each block contains a cryptographic hash of the previous one, forming a chain.
 In practice, the blockchain data structure actually optimizes BFT design.
 


### PR DESCRIPTION
Fix some minor typos that I noticed while skimming
over the introduction docs to get familiar with Tendermint.

* Pluralization of "user" instead of possesive "user's" to users.
* Capitalization of "tendermint" to "Tendermint".