### PR TITLE
peng/json md careers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build": " node build/build.js"
   },
   "dependencies": {
+    "axios": "^0.17.1",
     "highlight.js": "^9.12.0",
     "to-pascal-case": "^1.0.0",
     "vue": "2.2.2",

--- a/src/components/CardCareer.vue
+++ b/src/components/CardCareer.vue
@@ -1,11 +1,6 @@
 <template>
   <router-link :class="cssClass" :to="url">
     <div class="title">{{ career.title }}</div>
-    <div class="locations">
-      <div class="location" v-for="l in career.locations">
-        {{ l }}
-      </div>
-    </div>
   </router-link>
 </template>
 
@@ -14,7 +9,7 @@ export default {
   name: 'card-career',
   computed: {
     url () {
-      return '/careers/' + this.career.id
+      return '/careers/' + this.career.slug
     },
     cssClass () {
       let value = 'card-career'
@@ -27,7 +22,7 @@ export default {
 </script>
 
 <style lang="stylus">
-@require '../styles/variables.styl'
+@require '~variables'
 
 .card-career + .card-career
   border-top none

--- a/src/components/PageCareersEntry.vue
+++ b/src/components/PageCareersEntry.vue
@@ -1,35 +1,14 @@
 <template lang="pug">
 .page-career-entry
-  page-header(:title='career.title', :subtitle='subtitle', theme='tendermint')
+  page-header(:title='career.title' :subtitle='subtitle' theme='tendermint')
   article-body
-    div(v-if='career.description', v-html='markdownBlock(career.description)')
-    template(v-if='career.requirements.length > 0')
-      h2 We're looking for someone with…
-      ul
-        li(v-for='req in career.requirements', v-html='markdown(req)')
-    h2 You should be located near:
-    ul
-      li(v-for='loc in career.locations', v-html='markdown(loc)')
-    h2 You'll help us:
-    ul
-      li(v-for='task in career.tasks', v-html='markdown(task)')
-    h2 We'll offer:
-    ul
-      li Competitive salary
-      li Flexible hours (part-time or full-time)
-      li Stock options
-      li Medical, dental, and vision insurance
-      li An environment with plenty of opportunities to learn and innovate
-      li Exposure to cutting-edge blockchain technology
-      li Potential to work remotely later on
-      li And much more…
-    h2 Get in touch
-    p(v-if='career.contact', v-html='markdownBlock(career.contact)')
-    p(v-else='')
-      | Please submit a cover letter and resume to 
-      a(href='mailto:careers@tendermint.com') careers@tendermint.com
-      | . Make sure to include availability dates, desired working hours per week, and preferred location.  We'll write back as soon as we can.
-    btn(type='anchor', size='lg', href='mailto:careers@tendermint.com', icon='envelope-o', value='Send Application')
+    div(v-html="markdown(career.body)")
+    btn(
+      type='anchor'
+      size='lg'
+      href='mailto:careers@tendermint.com'
+      icon='envelope-o'
+      value='Send Application')
 </template>
 
 <script>
@@ -38,7 +17,6 @@ import ArticleBody from '@nylira/vue-article-body'
 import { mapGetters } from 'vuex'
 import MarkdownIt from 'markdown-it'
 import Btn from '@nylira/vue-button'
-let md = new MarkdownIt()
 export default {
   name: 'page-career-entry',
   components: {
@@ -47,28 +25,23 @@ export default {
     ArticleBody
   },
   computed: {
-    subtitle () {
-      return this.capitalize(this.career.area) + ' Position at Tendermint'
-    },
+    ...mapGetters(['allCareers']),
     career () {
       if (this.allCareers) {
-        return this.allCareers.find(c => c.id === this.$route.params.entry)
+        return this.allCareers.find(c => c.slug === this.$route.params.entry)
       }
-      return {
-        title: 'Loading...',
-        subtitle: 'Loading...'
-      }
+      return { title: 'Loading...', subtitle: 'Loading...' }
     },
-    ...mapGetters(['allCareers'])
+    subtitle () {
+      return this.capitalize(this.career.area) + ' Position at Tendermint'
+    }
   },
   methods: {
     capitalize (string) {
       return string.charAt(0).toUpperCase() + string.slice(1)
     },
     markdown (text) {
-      return md.renderInline(text)
-    },
-    markdownBlock (text) {
+      let md = new MarkdownIt()
       return md.render(text)
     },
     email (address) {
@@ -83,7 +56,7 @@ export default {
 
 
 <style lang="stylus">
-@require '../styles/variables.styl'
+@require '~variables'
 
 .page-career-entry
   .tags

--- a/src/components/PageCareersIndex.vue
+++ b/src/components/PageCareersIndex.vue
@@ -1,37 +1,28 @@
-<template>
-  <page-split class="page-careers-index">
-    <page-header
-      title="Careers"
-      subtitle="Join us at Tendermint to build and improve <a href='https://cosmos.network'>Cosmos</a> and Tendermint.<br><br>Jobs here are constantly updated. If your specialty is unlisted, we encourage you to still apply."
-      type="split"
-      slot="header"
-      theme="tendermint">
-      <!--
-      <div class="tags">
-        <div id="tag-all" class="tag active" @click="setActiveTag($event)">all</div>
-        <div class="tag" v-for="tag in tags" @click="setActiveTag($event,tag)">{{ tag }}</div>
-      </div>
-      -->
-    </page-header>
-    <ni-section v-if="technical.length > 0">
-      <div slot="title">Technical Positions</div>
-      <card-career v-for="c in technical" :key="c.id" :career="c"></card-career>
-    </ni-section>
-    <ni-section v-if="operations.length > 0">
-      <div slot="title">Operations Positions</div>
-      <card-career v-for="c in operations" :key="c.id" :career="c"></card-career>
-    </ni-section>
-    <ni-section v-if="community.length > 0">
-      <div slot="title">Community Positions</div>
-      <card-career v-for="c in community" :key="c.id" :career="c"></card-career>
-    </ni-section>
-  </page-split>
+<template lang="pug">
+page-split.page-careers-index
+  page-header(
+    title='Careers'
+    subtitle="Join us at Tendermint to build and improve <a href='https://cosmos.network'>Cosmos</a> and Tendermint.<br><br>Jobs here are constantly updated. If your specialty is unlisted, we encourage you to still apply."
+    type='split'
+    slot='header'
+    theme='tendermint')
+
+  ni-section(v-if='technical.length > 0')
+    div(slot='title') Technical Positions
+    card-career(v-for='c in technical', :key='c.id', :career='c')
+
+  ni-section(v-if='operations.length > 0')
+    div(slot='title') Operations Positions
+    card-career(v-for='c in operations', :key='c.id', :career='c')
+
+  ni-section(v-if='community.length > 0')
+    div(slot='title') Community Positions
+    card-career(v-for='c in community', :key='c.id', :career='c')
 </template>
 
 <script>
-import $ from 'jquery'
 import { mapGetters } from 'vuex'
-import { union, orderBy } from 'lodash'
+import { orderBy } from 'lodash'
 import CardCareer from './CardCareer'
 import NiSection from './NiSection'
 import PageHeader from '@nylira/vue-page-header'
@@ -45,45 +36,20 @@ export default {
     PageSplit
   },
   computed: {
-    tags () {
-      let tags = []
-      this.careers.map(function (career) {
-        tags = union(tags, career.tags)
-      })
-      return tags
-    },
     technical () {
-      return this.careers.filter(c => c.area === 'technical' && c.weight !== 0)
+      return this.careers.filter(c => c.area === 'technical')
     },
     operations () {
-      return this.careers.filter(c => c.area === 'operations' && c.weight !== 0)
+      return this.careers.filter(c => c.area === 'operations')
     },
     community () {
-      return this.careers.filter(c => c.area === 'community' && c.weight !== 0)
+      return this.careers.filter(c => c.area === 'community')
     },
     careers () {
       let orderedCareers = orderBy(this.allCareers, ['title'], ['asc'])
       return orderedCareers
     },
     ...mapGetters(['allCareers'])
-  },
-  data () {
-    return {
-      activeTag: 'all'
-    }
-  },
-  methods: {
-    setActiveTag ($event, tagName) {
-      $('.tag').removeClass('active')
-      if (tagName) {
-        $($event.target).addClass('active')
-        this.activeTag = tagName
-        return
-      }
-      $('#tag-all').addClass('active')
-      this.activeTag = 'all'
-      return
-    }
   },
   mounted () {
     document.title = 'Careers - Tendermint'
@@ -93,7 +59,7 @@ export default {
 
 
 <style lang="stylus">
-@require '../styles/variables.styl'
+@require '~variables'
 
 .page-careers-index
   .tags

--- a/src/router/routesRedirects.js
+++ b/src/router/routesRedirects.js
@@ -1,11 +1,22 @@
-export default [// download
-  { path: '/download', redirect: '/downloads' },
+export default [
   // redirect all blog posts to medium
   { path: '/posts', redirect: '/blog' },
   { path: '/posts/:entry', redirect: '/blog' },
   { path: '/blog/:entry', redirect: '/blog' },
+
+  // redirect old JSON Career urls to new Markdown Career urls
+  { path: '/careers/networking-consensus-engineer',
+    redirect: '/careers/developer-consensus' },
+  { path: '/careers/apps-developer', redirect: '/careers/developer-cosmos' },
+  { path: '/careers/devops-sysops-engineer', redirect: '/careers/developer-devops' },
+  { path: '/careers/ethereum-developer', redirect: '/careers/developer-ethereum' },
+  { path: '/careers/p2p-networking-engineer', redirect: '/careers/developer-p2p' },
+  { path: '/careers/ops-office-manager', redirect: '/careers/office-manager-sf' },
+  { path: '/careers/berlin-office-manager', redirect: '/careers/office-manager-berlin' },
+
   // other pages
   { path: '/code', redirect: '/docs' },
+  { path: '/download', redirect: '/downloads' },
   { path: '/guide', redirect: '/docs' },
   { path: '/jobs', redirect: '/careers' },
   { path: '/jobs/:entry', redirect: '/careers/:entry' },

--- a/src/store/modules/careers.js
+++ b/src/store/modules/careers.js
@@ -1,8 +1,67 @@
-let url = 'https://raw.githubusercontent.com/tendermint/aib-data/master/json/careers.json'
+import axios from 'axios'
 
-fetch(url)
-  .then(response => response.json())
-  .then(json => (state.all = json))
+let prefix = 'https://api.github.com/repos/tendermint/aib-data/contents/'
+let careerUrl = prefix + 'md/careers'
 
-const state = { all: '' }
-export default { state }
+async function getFiles (careerDirectory) {
+  return Promise.all(careerDirectory.map(c => {
+    let url = prefix + c.path
+    return getFile(url)
+  }))
+}
+
+async function getFile (url) {
+  return (await axios.get(url)).data
+}
+
+function addSlug (file) {
+  let slug = file.name.split('.')[0]
+  slug = slug.split('-')
+  slug.shift()
+  slug = slug.join('-')
+  file.slug = slug
+  return file
+}
+
+function addArea (file) {
+  file.area = file.name.split('-')[0]
+  return file
+}
+
+function addTitle (file) {
+  let body = window.atob(file.content)
+  let title = body.split('\n')[0]
+  let titleArray = title.split(' ')
+  titleArray.shift()
+  title = titleArray.join(' ')
+  file.title = title
+  return file
+}
+
+function addBody (file) {
+  let body = window.atob(file.content)
+  body = body.split('\n')
+  body.shift()
+  file.body = body.join('\n')
+  return file
+}
+
+async function getCareers (url) {
+  let dir = (await axios.get(careerUrl)).data
+  let careers = await getFiles(dir)
+  careers.map(c => addSlug(c))
+  careers.map(c => addArea(c))
+  careers.map(c => addTitle(c))
+  careers.map(c => addBody(c))
+  state.all = careers
+  return careers
+}
+
+getCareers()
+
+const state = {
+  all: []
+}
+const mutations = {}
+
+export default { state, mutations }

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,6 +341,13 @@ aws4@^1.2.1, aws4@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+axios@^0.17.1:
+  version "0.17.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.17.1.tgz#2d8e3e5d0bdbd7327f91bc814f5c57660f81824d"
+  dependencies:
+    follow-redirects "^1.2.5"
+    is-buffer "^1.1.5"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -1868,7 +1875,7 @@ de-indent@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
 
-debug@*:
+debug@*, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -2762,6 +2769,12 @@ flat-cache@^1.2.1:
 flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
+
+follow-redirects@^1.2.5:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.4.1.tgz#d8120f4518190f55aac65bb6fc7b85fcd666d6aa"
+  dependencies:
+    debug "^3.1.0"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This PR switches the data used for job listings from `aib-data/json/careers.json` to [`aib-data/md/careers`](https://github.com/tendermint/aib-data/tree/develop/md/careers). Using markdown files for careers allows for far more flexibility in communicating to potential hires. It's also easier for non-developers to edit.

Note: The old job urls will redirect to the new job urls.